### PR TITLE
feat: basic asdf plugin for kurtosis

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+root = true
+
+[*]
+indent_style = tab
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.{md,yml,yaml}]
+indent_style = space
+indent_size = 2

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2020 The asdf-vm core AUTHORS
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,55 @@
-# asdf-kurtosis
+<div align="center">
+
+# asdf-kurtosis [![Build](https://github.com/ethereum-optimism/asdf-kurtosis/actions/workflows/build.yml/badge.svg)](https://github.com/sigma/asdf-kurtosis/actions/workflows/build.yml) [![Lint](https://github.com/sigma/asdf-kurtosis/actions/workflows/lint.yml/badge.svg)](https://github.com/sigma/asdf-kurtosis/actions/workflows/lint.yml)
+
+[kurtosis](https://docs.kurtosis.com/) plugin for the [asdf version manager](https://asdf-vm.com).
+
+</div>
+
+# Contents
+
+- [Dependencies](#dependencies)
+- [Install](#install)
+- [Contributing](#contributing)
+- [License](#license)
+
+# Dependencies
+
+- `bash`, `curl`, `tar`, and [POSIX utilities](https://pubs.opengroup.org/onlinepubs/9699919799/idx/utilities.html).
+
+# Install
+
+Plugin:
+
+```shell
+asdf plugin add kurtosis
+# or
+asdf plugin add kurtosis https://github.com/ethereum-optimism/asdf-kurtosis.git
+```
+
+kurtosis:
+
+```shell
+# Show all installable versions
+asdf list-all kurtosis
+
+# Install specific version
+asdf install kurtosis latest
+
+# Set a version globally (on your ~/.tool-versions file)
+asdf global kurtosis latest
+
+# Now kurtosis commands are available
+kurtosis version
+```
+
+Check [asdf](https://github.com/asdf-vm/asdf) readme for more instructions on how to
+install & manage versions.
+
+# Contributing
+
+Contributions of any kind welcome! See the [contributing guide](contributing.md).
+
+# License
+
+All other files within this repository are licensed under the [MIT License](https://github.com/ethereum-optimism/asdf-kurtosis/blob/main/LICENSE) unless stated otherwise.

--- a/bin/download
+++ b/bin/download
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+current_script_path=${BASH_SOURCE[0]}
+plugin_dir=$(dirname "$(dirname "$current_script_path")")
+
+# shellcheck source=./lib/utils.bash
+source "${plugin_dir}/lib/utils.bash"
+
+mkdir -p "$ASDF_DOWNLOAD_PATH"
+
+release_file="$ASDF_DOWNLOAD_PATH/$TOOL_NAME-$ASDF_INSTALL_VERSION.tar.gz"
+
+# Download tar.gz file to the download directory
+download_release "$ASDF_INSTALL_VERSION" "$release_file"
+
+#  Extract contents of tar.gz file into the download directory
+tar -xzf "$release_file" -C "$ASDF_DOWNLOAD_PATH" --strip-components=1 || fail "Could not extract $release_file"
+
+# Remove the tar.gz file since we don't need to keep it
+rm "$release_file"

--- a/bin/install
+++ b/bin/install
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+current_script_path=${BASH_SOURCE[0]}
+plugin_dir=$(dirname "$(dirname "$current_script_path")")
+
+# shellcheck source=./lib/utils.bash
+source "${plugin_dir}/lib/utils.bash"
+
+install_version "$ASDF_INSTALL_TYPE" "$ASDF_INSTALL_VERSION" "$ASDF_INSTALL_PATH"

--- a/bin/latest-stable
+++ b/bin/latest-stable
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+current_script_path=${BASH_SOURCE[0]}
+plugin_dir=$(dirname "$(dirname "$current_script_path")")
+
+# shellcheck source=./lib/utils.bash
+. "${plugin_dir}/lib/utils.bash"
+
+curl_opts=(-sI)
+
+if [ -n "${GITHUB_API_TOKEN:-}" ]; then
+	curl_opts=("${curl_opts[@]}" -H "Authorization: token $GITHUB_API_TOKEN")
+fi
+
+# curl of REPO/releases/latest is expected to be a 302 to another URL
+# when no releases redirect_url="REPO/releases"
+# when there are releases redirect_url="REPO/releases/tag/v<VERSION>"
+redirect_url=$(curl "${curl_opts[@]}" "$GH_REPO/releases/latest" | sed -n -e "s|^location: *||p" | sed -n -e "s|\r||p")
+version=
+printf "redirect url: %s\n" "$redirect_url" >&2
+if [[ "$redirect_url" == "$GH_REPO/releases" ]]; then
+	version="$(list_all_versions | sort_versions | tail -n1 | xargs echo)"
+else
+	version="$(printf "%s\n" "$redirect_url" | sed 's|.*/tag/v\{0,1\}||')"
+fi
+
+printf "%s\n" "$version"

--- a/bin/list-all
+++ b/bin/list-all
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+current_script_path=${BASH_SOURCE[0]}
+plugin_dir=$(dirname "$(dirname "$current_script_path")")
+
+# shellcheck source=./lib/utils.bash
+source "${plugin_dir}/lib/utils.bash"
+
+list_all_versions | sort_versions | xargs echo

--- a/contributing.md
+++ b/contributing.md
@@ -1,0 +1,11 @@
+# Contributing
+
+Testing Locally:
+
+```shell
+asdf plugin test <plugin-name> <plugin-url> [--asdf-tool-version <version>] [--asdf-plugin-gitref <git-ref>] [test-command*]
+
+asdf plugin test kurtosis https://github.com/ethereum-optimism/asdf-kurtosis.git "kurtosis version"
+```
+
+Tests are automatically run in GitHub Actions on push and PR.

--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+GH_REPO="https://github.com/kurtosis-tech/kurtosis"
+TOOL_NAME="kurtosis"
+TOOL_TEST="kurtosis version"
+
+fail() {
+	echo -e "asdf-$TOOL_NAME: $*"
+	exit 1
+}
+
+curl_opts=(-fsSL)
+
+# NOTE: You might want to remove this if kurtosis is not hosted on GitHub releases.
+if [ -n "${GITHUB_API_TOKEN:-}" ]; then
+	curl_opts=("${curl_opts[@]}" -H "Authorization: token $GITHUB_API_TOKEN")
+fi
+
+sort_versions() {
+	sed 'h; s/[+-]/./g; s/.p\([[:digit:]]\)/.z\1/; s/$/.z/; G; s/\n/ /' |
+		LC_ALL=C sort -t. -k 1,1 -k 2,2n -k 3,3n -k 4,4n -k 5,5n | awk '{print $2}'
+}
+
+list_github_tags() {
+	git ls-remote --tags --refs "$GH_REPO" |
+		grep -o 'refs/tags/.*' | cut -d/ -f3- | grep -v '/' | # Remove tags that are not module-specific
+		sed 's/^v//'
+}
+
+list_all_versions() {
+	list_github_tags
+}
+
+download_release() {
+	local version filename url
+	version="$1"
+	filename="$2"
+
+	url="$GH_REPO/archive/refs/tags/${version}.tar.gz"
+
+	echo "* Downloading $TOOL_NAME release $version..."
+	curl "${curl_opts[@]}" -o "$filename" -C - "$url" || fail "Could not download $url"
+}
+
+install_version() {
+	local install_type="$1"
+	local version="$2"
+	local install_path="${3%/bin}/bin"
+
+	if [ "$install_type" != "version" ]; then
+		fail "asdf-$TOOL_NAME supports release installs only"
+	fi
+
+	(
+		mkdir -p "$install_path"
+
+		cd "$ASDF_DOWNLOAD_PATH"
+		mkdir bin/
+		./scripts/generate-kurtosis-version.sh "$version"
+		go build -o bin/kurtosis ./cli/cli
+
+		cp -r bin/* "$install_path"
+
+		local tool_cmd
+		tool_cmd="$(echo "$TOOL_TEST" | cut -d' ' -f1)"
+		test -x "$install_path/$tool_cmd" || fail "Expected $install_path/$tool_cmd to be executable."
+
+		echo "$TOOL_NAME $version installation was successful!"
+	) || (
+		rm -rf "$install_path"
+		fail "An error occurred while installing $TOOL_NAME $version."
+	)
+}

--- a/scripts/format.bash
+++ b/scripts/format.bash
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+shfmt --language-dialect bash --write \
+	./**/*

--- a/scripts/lint.bash
+++ b/scripts/lint.bash
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+shellcheck --shell=bash --external-sources \
+	bin/* --source-path=template/lib/ \
+	lib/* \
+	scripts/*
+
+shfmt --language-dialect bash --diff \
+	./**/*


### PR DESCRIPTION
**Description**

Basic asdf plugin for install kurtosis.
Since kurtosis is not go-installable, we need that to integrate into our mise definition in ethereum-optimism/optimism

**Tests**

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
